### PR TITLE
[Pal/Linux-SGX] Fix refcounting on open/close of Protected Files

### DIFF
--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -1,5 +1,6 @@
 /*.manifest
 /*.xml
+/*.dat
 
 /.cache
 /abort
@@ -76,6 +77,7 @@
 /proc_common
 /proc_cpuinfo
 /proc_path
+/protected_file
 /pselect
 /pthread_set_get_affinity
 /rdtsc

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -177,6 +177,7 @@ clean-tmp:
 		*.sig \
 		*.tmp \
 		*.token \
+		*.dat \
 		*~ \
 		.cache \
 		.pytest_cache \

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -67,6 +67,7 @@ c_executables = \
 	proc_common \
 	proc_cpuinfo \
 	proc_path \
+	protected_file \
 	pselect \
 	pthread_set_get_affinity \
 	readdir \

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -40,3 +40,7 @@ sgx.allowed_files.testfile = "file:testfile" # for mmap_file test
 sgx.thread_num = 16
 
 sgx.nonpie_binary = 1
+
+# for protected_file test
+sgx.protected_files.pf1 = "file:protected_file_1.dat"
+sgx.protected_files_key = "ffeeddccbbaa99887766554433221100"

--- a/LibOS/shim/test/regression/protected_file.c
+++ b/LibOS/shim/test/regression/protected_file.c
@@ -1,0 +1,84 @@
+/* This test opens the same file twice, reads from one FD, reads from another FD, and closes both
+ * FDs. This test exists mainly to test Protected Files Linux-SGX feature. */
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define BUF_LENGTH 256
+#define STRING "Hello World"
+
+static ssize_t rw_file(int fd, char* buf, size_t bytes, bool write_flag) {
+    ssize_t rv = 0;
+    ssize_t ret;
+
+    while (bytes > rv) {
+        if (write_flag)
+            ret = write(fd, buf + rv, bytes - rv);
+        else
+            ret = read(fd, buf + rv, bytes - rv);
+
+        if (ret > 0) {
+            rv += ret;
+        } else {
+            if (ret < 0 && (errno == EAGAIN || errno == EINTR)) {
+                continue;
+            } else {
+                fprintf(stderr, "%s failed:%s\n", write_flag ? "write" : "read", strerror(errno));
+                return ret;
+            }
+        }
+    }
+
+    return rv;
+}
+
+int main(int argc, char** argv) {
+    int ret;
+    char buf[BUF_LENGTH] = {0};
+    ssize_t bytes;
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s protected_file_path\n", argv[0]);
+        return 1;
+    }
+
+    char* protected_file_path = argv[1];
+    int fd1 = open(protected_file_path, O_CREAT | O_RDONLY, 0644);
+    if (fd1 < 0)
+        err(1, "open of first fd");
+
+    int fd2 = open(protected_file_path, O_CREAT | O_RDWR, 0644);
+    if (fd2 < 0)
+        err(1, "open of second fd");
+
+    bytes = rw_file(fd2, STRING, sizeof(STRING), /*write_flag=*/true);
+    if (bytes != sizeof(STRING))
+        errx(1, "writing '" STRING "' to second fd failed");
+
+    bytes = rw_file(fd1, buf, sizeof(STRING), /*write_flag=*/false);
+    if (bytes < 0)
+        errx(1, "reading '" STRING "' from first fd failed");
+
+    buf[bytes - 1] = '\0';
+
+    if (strcmp(STRING, buf))
+        errx(1, "unexpected '%s' was read", buf);
+
+    ret = close(fd2);
+    if (ret < 0)
+        err(1, "close of second fd");
+
+    ret = close(fd1);
+    if (ret < 0)
+        err(1, "close of first fd");
+
+    puts("TEST OK");
+    return 0;
+}

--- a/LibOS/shim/test/regression/protected_file.c
+++ b/LibOS/shim/test/regression/protected_file.c
@@ -1,4 +1,4 @@
-/* This test opens the same file twice, reads from one FD, reads from another FD, and closes both
+/* This test opens the same file twice, writes to one FD, reads from another FD, and closes both
  * FDs. This test exists mainly to test Protected Files Linux-SGX feature. */
 
 #include <err.h>

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -381,6 +381,12 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['file_size'])
         self.assertIn('test completed successfully', stdout)
 
+    def test_033_protected_file(self):
+        if os.path.exists("protected_file_1.dat"):
+            os.remove("protected_file_1.dat")
+        stdout, _ = self.run_binary(['protected_file', 'protected_file_1.dat'])
+        self.assertIn('TEST OK', stdout)
+
     def test_040_futex_bitset(self):
         stdout, _ = self.run_binary(['futex_bitset'])
 

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -376,7 +376,7 @@ static int register_protected_path(const char* path, struct protected_file** new
 
     memcpy(new->path, path, new->path_len + 1);
     new->refcount = 0;
-    new->writable_fd = -1;
+    new->host_fd = -1;
 
     bool is_dir;
     ret = is_directory(path, &is_dir);

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -177,8 +177,8 @@ struct protected_file {
     size_t path_len;
     char* path;
     pf_context_t* context; /* NULL until PF is opened */
-    int64_t refcount; /* used for deciding when to call unload_protected_file() */
-    int writable_fd; /* fd of underlying file for writable PF, -1 if no writable handles are open */
+    int64_t refcount;      /* used for deciding when to call unload_protected_file() */
+    int host_fd;           /* -1 until PF is opened */
 };
 
 /* Initialize the PF library, register PFs from the manifest */

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -1236,6 +1236,23 @@ pf_status_t pf_close(pf_context_t* pf) {
     return pf->last_error;
 }
 
+pf_status_t pf_get_mode(pf_context_t* pf, pf_file_mode_t* mode) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    *mode = pf->mode;
+    return PF_STATUS_SUCCESS;
+}
+
+pf_status_t pf_set_mode(pf_context_t* pf, pf_file_mode_t mode) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    assert((pf->mode & mode) == pf->mode); /* can only extend old mode, cannot narrow it */
+    pf->mode = mode;
+    return PF_STATUS_SUCCESS;
+}
+
 pf_status_t pf_get_size(pf_context_t* pf, uint64_t* size) {
     if (!g_initialized)
         return PF_STATUS_UNINITIALIZED;

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -226,6 +226,24 @@ pf_status_t pf_read(pf_context_t* pf, uint64_t offset, size_t size, void* output
 pf_status_t pf_write(pf_context_t* pf, uint64_t offset, size_t size, const void* input);
 
 /*!
+ * \brief Get access mode (read-only, write-only, read-write) of a PF
+ *
+ * \param [in] pf PF context
+ * \param [out] mode Access mode of \a pf
+ * \return PF status
+ */
+pf_status_t pf_get_mode(pf_context_t* pf, pf_file_mode_t* mode);
+
+/*!
+ * \brief Set access mode (read-only, write-only, read-write) of a PF
+ *
+ * \param [in] pf PF context
+ * \param [in] mode New access mode of \a pf
+ * \return PF status
+ */
+pf_status_t pf_set_mode(pf_context_t* pf, pf_file_mode_t mode);
+
+/*!
  * \brief Get data size of a PF
  *
  * \param [in] pf PF context


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `file_open()` and `file_close()` on a Protected File had weird semnatics: if the same PF was opened twice, there was only one PF context created, but there were several underlying host FDs. Even weirder, the PF context tied itself to the host FD (the very first opened one) using the pointer to this FD: `&pal_handle->file.fd`.

This resulted in bugs and cumbersome workarounds: the associated PAL handle could be closed and freed by our common PAL code, and the PF context would contain a dangling pointer. And for `file_attrquery()`, there was a workaround to destroy the PAL context if it seemed to be created only for this attrquery flow (this was based on this pointer-to-pal-handle-fd).

This PR fixes these bugs: the PF context stores the underlying host FD directly, and doesn't open new FDs on subsequent `file_open()`. So, there is always only one host FD for one PF context. As a side effect, the logic of `file_open()` and `file_close()` is refactored.

A new LibOS regression test `protected_file` is added for GDB debugging because the dedicated `fs/` tests are harder to debug.

Fixes #2360.

## How to test this PR? <!-- (if applicable) -->

A new test is added. Also, `fs/pf-test` should succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/graphene/2372)
<!-- Reviewable:end -->
