### PR TITLE
[LibOS] Fix setting of `O_NONBLOCK` flag at the write end of pipe

### DIFF
--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -53,7 +53,10 @@ static int create_pipes(struct shim_handle* srv, struct shim_handle* cli, int fl
     srv->pal_handle = hdl1;
 
     if (flags & O_NONBLOCK) {
-        /* `cli` - `hdl2` - has this flag already set by the call to `DkStreamOpen`. */
+        ret = set_handle_nonblocking(cli, /*on=*/true);
+        if (ret < 0)
+            goto out;
+
         ret = set_handle_nonblocking(srv, /*on=*/true);
         if (ret < 0) {
             /* Restore original handle, if any. */

--- a/LibOS/shim/test/regression/pipe_nonblocking.c
+++ b/LibOS/shim/test/regression/pipe_nonblocking.c
@@ -26,6 +26,12 @@ int main(void) {
         errx(1, "Expected O_NONBLOCK flag to be set on both ends of pipe but got flags_wr=0x%x, "
             "flags_rd=0x%x", flags_wr, flags_rd);
 
+    flags_rd = flags_rd & ~O_ACCMODE;
+    flags_wr = flags_wr & ~O_ACCMODE;
+
+    if (flags_wr != flags_rd)
+        errx(1, "`F_GETFL` flags mismatch: flags_wr=0x%x and flags_rd=0x%x", flags_wr, flags_rd);
+
     flags_wr = fcntl(p[1], F_GETFD);
     if (flags_wr < 0)
         err(1, "fcntl(<write end of pipe>, F_GETFD)");
@@ -38,6 +44,12 @@ int main(void) {
     if (!(flags_wr & FD_CLOEXEC) || !(flags_rd & FD_CLOEXEC))
         errx(1, "Expected O_CLOEXEC flag to be set on both ends of pipe but got flags_wr=0x%x, "
              "flags_rd=0x%x", flags_wr, flags_rd);
+
+    flags_rd = flags_rd & ~O_ACCMODE;
+    flags_wr = flags_wr & ~O_ACCMODE;
+
+    if (flags_wr != flags_rd)
+        errx(1, "`F_GETFD` flags mismatch: flags_wr=0x%x and flags_rd=0x%x", flags_wr, flags_rd);
 
     ssize_t ret = write(p[1], "a", 1);
     if (ret < 0) {

--- a/LibOS/shim/test/regression/pipe_nonblocking.c
+++ b/LibOS/shim/test/regression/pipe_nonblocking.c
@@ -12,6 +12,33 @@ int main(void) {
         err(1, "pipe2");
     }
 
+    /* Verify both ends of the pipe provide same flags. */
+    int flags_wr = fcntl(p[1], F_GETFL);
+    if (flags_wr < 0)
+        err(1, "fcntl(<write end of pipe>, F_GETFL)");
+
+    int flags_rd = fcntl(p[0], F_GETFL);
+    if (flags_rd < 0)
+        err(1, "fcntl(<read end of pipe>, F_GETFL)");
+
+    /* Ensure O_NONBLOCK flag is properly set on both ends of pipe. */
+    if (!(flags_wr & O_NONBLOCK) || !(flags_rd & O_NONBLOCK))
+        errx(1, "Expected O_NONBLOCK flag to be set on both ends of pipe but got flags_wr=0x%x, "
+            "flags_rd=0x%x", flags_wr, flags_rd);
+
+    flags_wr = fcntl(p[1], F_GETFD);
+    if (flags_wr < 0)
+        err(1, "fcntl(<write end of pipe>, F_GETFD)");
+
+    flags_rd = fcntl(p[0], F_GETFD);
+    if (flags_rd < 0)
+        err(1, "fcntl(<read end of pipe>, F_GETFD)");
+
+    /* Ensure O_CLOEXEC flag is properly set on both ends of pipe. */
+    if (!(flags_wr & FD_CLOEXEC) || !(flags_rd & FD_CLOEXEC))
+        errx(1, "Expected O_CLOEXEC flag to be set on both ends of pipe but got flags_wr=0x%x, "
+             "flags_rd=0x%x", flags_wr, flags_rd);
+
     ssize_t ret = write(p[1], "a", 1);
     if (ret < 0) {
         err(1, "write");

--- a/LibOS/shim/test/regression/pipe_nonblocking.c
+++ b/LibOS/shim/test/regression/pipe_nonblocking.c
@@ -45,9 +45,6 @@ int main(void) {
         errx(1, "Expected O_CLOEXEC flag to be set on both ends of pipe but got flags_wr=0x%x, "
              "flags_rd=0x%x", flags_wr, flags_rd);
 
-    flags_rd = flags_rd & ~O_ACCMODE;
-    flags_wr = flags_wr & ~O_ACCMODE;
-
     if (flags_wr != flags_rd)
         errx(1, "`F_GETFD` flags mismatch: flags_wr=0x%x and flags_rd=0x%x", flags_wr, flags_rd);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Currently, in Graphene we don't save the `O_NONBLOCK` flag for the write end of the pipe. We set the `O_NONBLOCK` flag for the PAL_HANDLE but this isn't propagated to the SHIM_HANDLE when creating pipe. This commit fixes the corner case.

Also, updated the `pipe_nonblocking` regression test to catch this corner case.

## How to test this PR? <!-- (if applicable) -->
Please run both `graphene-direct` and `graphene-sgx` regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/graphene/2524)
<!-- Reviewable:end -->
