### PR TITLE
[Pal/Linux] Cap max available address for LibOS's memory management

### DIFF
--- a/Pal/include/arch/x86_64/Linux/pal_host-arch.h
+++ b/Pal/include/arch/x86_64/Linux/pal_host-arch.h
@@ -25,6 +25,12 @@ static inline int pal_set_tcb(PAL_TCB* tcb) {
     return INLINE_SYSCALL(arch_prctl, 2, ARCH_SET_GS, tcb);
 }
 
+/* Linux PAL is loaded at a random address by the host Linux because of ASLR (approx. at 0x7f...
+ * address). The macro below is a max available address for LibOS memory management, chosen to
+ * preclude a case when the checkpointed-by-parent memory region overlaps with Linux PAL
+ * executable's memory region during restore-by-child. */
+#define MMAP_MAX_ADDR 0x555555554000ul
+
 #endif /* IN_PAL */
 
 #endif /* __LINUX_X86_64_PAL_HOST_ARCH_H__ */

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -102,8 +102,14 @@ static void read_args_from_stack(void* initial_rsp, int* out_argc, const char***
 }
 
 void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
-    void* end_addr = (void*)ALLOC_ALIGN_DOWN_PTR(TEXT_START);
     void* start_addr = (void*)MMAP_MIN_ADDR;
+    void* end_addr   = (void*)MMAP_MAX_ADDR;
+
+    if ((uintptr_t)ALLOC_ALIGN_DOWN_PTR(TEXT_START) < (uintptr_t)end_addr)
+        end_addr = (void*)ALLOC_ALIGN_DOWN_PTR(TEXT_START);
+
+    if (g_pal_internal_mem_addr && (uintptr_t)g_pal_internal_mem_addr < (uintptr_t)end_addr)
+        end_addr = g_pal_internal_mem_addr;
 
     assert(IS_ALLOC_ALIGNED_PTR(start_addr) && IS_ALLOC_ALIGNED_PTR(end_addr));
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

During fork, the parent process checkpoints LibOS-managed memory regions and the child process restores them at the exact same addresses. However, the child process's main executable (`libpal.so`) may be mapped randomly because we don't use fork for this emulation (which would preserve the libpal.so memory mapping) but execve (which allows Linux host to perform ASLR on `libpal.so`). This leads to transient failures of the child because its `libpal.so`'s memory region may overlap with restored-from-checkpoint memory regions.

This commit restricts the memory range accessible to LibOS for memory management. Since Linux allocates from the top of the x86-64 address range (in approx. `0x7f...` range), we hard-code a max available address for LibOS memory management to definitely not overlap with `0x7f...` range.

For more context, see https://github.com/oscarlab/graphene/issues/2589.

Fixes #2589.

## How to test this PR? <!-- (if applicable) -->

Try stress-ng manually (#2589).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/graphene/2595)
<!-- Reviewable:end -->
