### PR TITLE
[LibOS] Return a partial write in `do_sendmsg` if host-level write was partial

### DIFF
--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1142,6 +1142,11 @@ static ssize_t do_sendmsg(int fd, struct iovec* bufs, int nbufs, int flags,
         }
 
         bytes += this_size;
+
+        /* gap in iovecs is not allowed, return a partial write to user; it is the responsibility
+         * of user application to deal with partial writes */
+        if (this_size < bufs[i].iov_len)
+            break;
     }
 
     if (bytes)


### PR DESCRIPTION
Signed-off-by: Jitender Kumar <jitender.kumar@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, `do_sendmsg` iterated through all iovec buffers supplied by the user, regardless of whether the host-level write to the socket (via `DkStreamWrite`) was able to send the whole buffer or only part of the buffer. 

This could lead to data corruptions: Graphene would send only some parts of the buffers (i.e., with gaps) but would report to the user app the total sum of sent bytes (i.e., without gaps).

This PR fixes this by simply bailing out on the first encountered host-level partial write.

Fixes #2664


## How to test this PR? <!-- (if applicable) -->
Create a communication channel between client and server and send large size data for example 4194299 bytes multiple times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/graphene/2679)
<!-- Reviewable:end -->
